### PR TITLE
feat(repo-manager): OSS-212: Add better template support - creating/viewing

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@fontsource-variable/work-sans':
         specifier: ^5.2.5
         version: 5.2.5
-      '@kunai-consulting/qwik':
-        specifier: ^0.2.0
-        version: 0.2.0
       octokit:
         specifier: ^4.1.3
         version: 4.1.3
@@ -36,6 +33,9 @@ importers:
       '@kunai-consulting/kunai-design-system':
         specifier: ^0.0.8
         version: 0.0.8(@builder.io/qwik@1.13.0(vite@5.3.5(@types/node@20.14.11)(lightningcss@1.29.2)))
+      '@kunai-consulting/qwik':
+        specifier: ^0.2.0
+        version: 0.2.0
       '@modular-forms/qwik':
         specifier: ^0.29.1
         version: 0.29.1(@builder.io/qwik-city@1.13.0(acorn@8.14.1)(rollup@4.40.2)(typescript@5.4.5)(vite@5.3.5(@types/node@20.14.11)(lightningcss@1.29.2)))(@builder.io/qwik@1.13.0(vite@5.3.5(@types/node@20.14.11)(lightningcss@1.29.2)))(typescript@5.4.5)

--- a/src/components/forms/createRepoFromTemplateForm.tsx
+++ b/src/components/forms/createRepoFromTemplateForm.tsx
@@ -1,0 +1,171 @@
+import { $, component$, useComputed$ } from "@builder.io/qwik";
+import { useForm, zodForm$, reset } from "@modular-forms/qwik";
+import { TextInput } from "~/components/formInputs/textInput";
+import { SelectInput } from "~/components/formInputs/selectInput";
+import { Button } from "@kunai-consulting/kunai-design-system";
+import { useCreateTemplateRepository, useGetRepos } from "~/routes/layout";
+import {
+  type CreateRepositoryFromTemplateFormType,
+  createRepositoryFromTemplateSchema,
+} from "~/db/createRepository";
+import { Repo } from "~/db/types";
+
+export interface CreateRepositoryFromTemplateFormProps {
+  repos: Repo[];
+}
+
+export const CreateRepositoryFromTemplateForm =
+  component$<CreateRepositoryFromTemplateFormProps>(({ repos }) => {
+    const createRepository = useCreateTemplateRepository();
+    const templateRepos = useComputed$(() => {
+      return repos.filter((r) => r.is_template);
+    });
+    const [form, { Form, Field }] = useForm<
+      CreateRepositoryFromTemplateFormType,
+      { url: string }
+    >({
+      loader: {
+        value: {
+          repoType: "user",
+          repoName: "",
+          visibility: "public",
+          repoDescription: "",
+          templateRepo: undefined,
+        },
+      },
+      validate: zodForm$(createRepositoryFromTemplateSchema),
+      action: createRepository,
+    });
+
+    const handleReset = $(() => {
+      reset(form);
+    });
+
+    return (
+      <div>
+        <Form>
+          <div class="grid grid-cols-2 gap-4">
+            <h5 class="text-lg dark:text-white font-semibold col-span-2">
+              General Information
+            </h5>
+            <Field name="repoType">
+              {(field, props) => {
+                return (
+                  <SelectInput
+                    {...props}
+                    label="Repository Type"
+                    value={field.value}
+                    error={field.error}
+                    options={[
+                      { value: "user", label: "User" },
+                      { value: "org", label: "Organization" },
+                    ]}
+                  />
+                );
+              }}
+            </Field>
+            <Field name="repoName">
+              {(field, props) => {
+                return (
+                  <TextInput
+                    {...props}
+                    type="text"
+                    label="Repository Name"
+                    value={field.value}
+                    error={field.error}
+                    required
+                  />
+                );
+              }}
+            </Field>
+            <Field name="templateRepo">
+              {(field, props) => {
+                return (
+                  <SelectInput
+                    {...props}
+                    label="Create from Template"
+                    value={field.value}
+                    error={field.error}
+                    options={templateRepos.value.map((repo) => ({
+                      value: repo.name ?? "",
+                      label: repo.name ?? "",
+                    }))}
+                  />
+                );
+              }}
+            </Field>
+            <Field name="repoDescription">
+              {(field, props) => {
+                return (
+                  <TextInput
+                    {...props}
+                    type="text"
+                    label="Repository Description"
+                    value={field.value}
+                    error={field.error}
+                  />
+                );
+              }}
+            </Field>
+            <Field name="visibility">
+              {(field, props) => {
+                return (
+                  <SelectInput
+                    {...props}
+                    label="Visibility"
+                    value={field.value}
+                    error={field.error}
+                    options={[
+                      { value: "public", label: "Public" },
+                      { value: "private", label: "Private" },
+                    ]}
+                  />
+                );
+              }}
+            </Field>
+          </div>
+          <div class="flex gap-4 justify-end mt-4">
+            <Button
+              class="cursor-pointer"
+              kind="secondary"
+              onClick$={handleReset}
+              type="button"
+              disabled={form.submitting}
+            >
+              Clear
+            </Button>
+            <Button
+              class="cursor-pointer"
+              type="submit"
+              disabled={form.submitting}
+            >
+              Create Repository
+            </Button>
+          </div>
+          <div class="flex gap-4 justify-end mt-4">
+            {form.submitting && (
+              <span class="text-sm text-gray-500">Submitting...</span>
+            )}
+            {form.response.status === "success" && (
+              <>
+                <div class="text-sm text-green-500">
+                  {form.response.message}
+                </div>
+                <a
+                  href={form.response.data?.url}
+                  target="_blank"
+                  class="dark:text-white"
+                >
+                  View on GitHub
+                </a>
+              </>
+            )}
+
+            {form.response.status === "error" && (
+              <span class="text-sm text-red-500">{form.response.message}</span>
+            )}
+          </div>
+        </Form>
+      </div>
+    );
+  });

--- a/src/components/forms/createRepoFromTemplateForm.tsx
+++ b/src/components/forms/createRepoFromTemplateForm.tsx
@@ -3,7 +3,7 @@ import { useForm, zodForm$, reset } from "@modular-forms/qwik";
 import { TextInput } from "~/components/formInputs/textInput";
 import { SelectInput } from "~/components/formInputs/selectInput";
 import { Button } from "@kunai-consulting/kunai-design-system";
-import { useCreateTemplateRepository, useGetRepos } from "~/routes/layout";
+import { useCreateTemplateRepository } from "~/routes/layout";
 import {
   type CreateRepositoryFromTemplateFormType,
   createRepositoryFromTemplateSchema,

--- a/src/components/repoDetails/repoDetails.tsx
+++ b/src/components/repoDetails/repoDetails.tsx
@@ -11,7 +11,7 @@ import {
 import { TopicsModal } from "~/components/modals/topicsModal";
 import { Routes } from "~/config/routes";
 export interface RepoDetailsProps {
-  repoDetails?: Repo;
+  repoDetails?: Repo | null;
   isDesignSystem?: boolean;
 }
 

--- a/src/db/createRepository.ts
+++ b/src/db/createRepository.ts
@@ -42,7 +42,18 @@ export const createRepositorySchema = z
     { message: "At least one merge method must be enabled" },
   );
 
+export const createRepositoryFromTemplateSchema = z.object({
+  repoType: z.enum(["user", "org"]).default("user"),
+  repoName: z.string().min(1, "Repository name is required"),
+  repoDescription: z.string().optional(),
+  visibility: z.enum(["public", "private"]).default("public").optional(),
+  templateRepo: z.string(),
+});
+
 export type CreateRepositoryFormType = z.infer<typeof createRepositorySchema>;
+export type CreateRepositoryFromTemplateFormType = z.infer<
+  typeof createRepositoryFromTemplateSchema
+>;
 
 /**
  * Creates a new GitHub repository based on the provided form data.
@@ -108,6 +119,7 @@ export const useCreateRepository = formAction$<
       });
       url = repo.data.html_url;
     }
+
     return {
       data: { url },
       status: "success",
@@ -122,3 +134,23 @@ export const useCreateRepository = formAction$<
     };
   }
 }, zodForm$(createRepositorySchema));
+
+export const useCreateTemplateRepository = formAction$<
+  CreateRepositoryFromTemplateFormType,
+  { url: string }
+>(async (formData, event) => {
+  const octokit: Octokit = event.sharedMap.get(OCTOKIT_CLIENT);
+  const repo = await octokit.rest.repos.createUsingTemplate({
+    template_owner: metadata.owner,
+    template_repo: formData.templateRepo!,
+    owner: formData.repoType === "org" ? metadata.owner : undefined,
+    name: formData.repoName,
+    description: formData.repoDescription,
+    private: formData.visibility === "private",
+  });
+  return {
+    data: { url: repo.data.html_url },
+    status: "success",
+    message: "Repository created successfully",
+  };
+}, zodForm$(createRepositoryFromTemplateSchema));

--- a/src/db/createRepository.ts
+++ b/src/db/createRepository.ts
@@ -142,7 +142,7 @@ export const useCreateTemplateRepository = formAction$<
   const octokit: Octokit = event.sharedMap.get(OCTOKIT_CLIENT);
   const repo = await octokit.rest.repos.createUsingTemplate({
     template_owner: metadata.owner,
-    template_repo: formData.templateRepo!,
+    template_repo: formData.templateRepo,
     owner: formData.repoType === "org" ? metadata.owner : undefined,
     name: formData.repoName,
     description: formData.repoDescription,

--- a/src/db/metadata.json
+++ b/src/db/metadata.json
@@ -6,7 +6,9 @@
     "mock-repo-with-no-dependencies",
     "mock-repo-with-also-one-dependency",
     "mock-repo-with-one-dependency",
-    "mock-web-app-repo"
+    "mock-web-app-repo",
+    "tester-test3",
+    "test-template-repo"
   ],
   "owner": "Many-Repo-Manager-PoC",
   "dependencyPaths": [

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -27,6 +27,8 @@ export interface Repo {
     type: string;
   };
   repoOwner?: string;
+  is_template?: boolean;
+  template_repository?: Repo | null;
 }
 
 export interface Dependency {

--- a/src/routes/allRepositories/[repoOwner]/[name]/index.tsx
+++ b/src/routes/allRepositories/[repoOwner]/[name]/index.tsx
@@ -1,5 +1,5 @@
 import { component$ } from "@builder.io/qwik";
-import { type DocumentHead, Link, useLocation } from "@builder.io/qwik-city";
+import { type DocumentHead, useLocation } from "@builder.io/qwik-city";
 import { useGetPackageJson, useGetRepos } from "~/routes/layout";
 import { TabbedCard } from "~/components/cards/tabbedCard";
 import { PageTitle } from "~/components/page/pageTitle";
@@ -8,12 +8,10 @@ import type { Repo } from "~/db/types";
 import { RepoDetails } from "~/components/repoDetails/repoDetails";
 import { RepoDependencyCard } from "~/components/cards/repoDependencyCard";
 import { Routes } from "~/config/routes";
-import { Button } from "@kunai-consulting/kunai-design-system";
 
 export default component$(() => {
   const repos = useGetRepos();
   const packageJson = useGetPackageJson();
-  const location = useLocation();
   const { name: repoName } = useLocation().params;
   const tabList = ["Details", "Dependencies"];
 

--- a/src/routes/allRepositories/[repoOwner]/[name]/index.tsx
+++ b/src/routes/allRepositories/[repoOwner]/[name]/index.tsx
@@ -1,5 +1,5 @@
 import { component$ } from "@builder.io/qwik";
-import { type DocumentHead, useLocation } from "@builder.io/qwik-city";
+import { type DocumentHead, Link, useLocation } from "@builder.io/qwik-city";
 import { useGetPackageJson, useGetRepos } from "~/routes/layout";
 import { TabbedCard } from "~/components/cards/tabbedCard";
 import { PageTitle } from "~/components/page/pageTitle";
@@ -7,19 +7,39 @@ import { DependencyUpdaterCard } from "~/components/cards/dependencyUpdaterCard"
 import type { Repo } from "~/db/types";
 import { RepoDetails } from "~/components/repoDetails/repoDetails";
 import { RepoDependencyCard } from "~/components/cards/repoDependencyCard";
+import { Routes } from "~/config/routes";
+import { Button } from "@kunai-consulting/kunai-design-system";
 
 export default component$(() => {
   const repos = useGetRepos();
   const packageJson = useGetPackageJson();
+  const location = useLocation();
   const { name: repoName } = useLocation().params;
-  const tabList = ["Details", "Dependencies", "Dependents"];
+  const tabList = ["Details", "Dependencies"];
 
   const repo = repos.value.data?.repositories.find((r) => r.name === repoName);
   const repoTopics = repo?.topics;
+  const isTemplate = repo?.is_template;
   const isDesignSystem = repoTopics?.includes("design-system");
-  if (!isDesignSystem) {
-    tabList.pop();
+  let childRepos: Repo[] = [];
+
+  if (isDesignSystem) {
+    tabList.push("Dependents");
   }
+
+  // TODO: This will likely be removed in the future in favor pulling this from the database
+  if (isTemplate) {
+    childRepos =
+      repos.value.data?.repositories.filter(
+        (r) => r.template_repository?.id === repo?.id,
+      ) ?? [];
+    tabList.push("Child Repos");
+  }
+
+  if (repo?.template_repository) {
+    tabList.push("Parent Template");
+  }
+
   if (repos.value.failed) {
     return <div>Error: {repos.value.message}</div>;
   }
@@ -45,6 +65,29 @@ export default component$(() => {
             repo={repo as Repo}
             packageJson={packageJson.value}
           />
+        </div>
+        <div q:slot="Parent Template">
+          <RepoDetails repoDetails={repo?.template_repository} />
+        </div>
+        <div q:slot="Child Repos">
+          {childRepos.length > 0 ? (
+            <div class="space-y-2">
+              {childRepos.map((childRepo) => (
+                <a
+                  key={childRepo.id}
+                  href={Routes.repoDetails(
+                    childRepo.owner?.login,
+                    childRepo.name,
+                  )}
+                  class="block text-kunai-blue-600 dark:text-kunai-blue-400 hover:underline"
+                >
+                  {childRepo.name}
+                </a>
+              ))}
+            </div>
+          ) : (
+            <p class="text-gray-500">No child repositories found.</p>
+          )}
         </div>
       </TabbedCard>
     </div>

--- a/src/routes/createRepositories/index.tsx
+++ b/src/routes/createRepositories/index.tsx
@@ -1,10 +1,15 @@
-import { component$ } from "@builder.io/qwik";
+import { component$, useSignal } from "@builder.io/qwik";
 import { type DocumentHead } from "@builder.io/qwik-city";
+import { Button } from "@kunai-consulting/kunai-design-system";
 import { BaseCard } from "~/components/cards/baseCard";
 import { CreateRepositoryForm } from "~/components/forms/createRepoForm";
+import { CreateRepositoryFromTemplateForm } from "~/components/forms/createRepoFromTemplateForm";
 import { PageTitle } from "~/components/page/pageTitle";
+import { useGetRepos } from "~/db/getRepositories";
 
 export default component$(() => {
+  const repos = useGetRepos();
+  const showTemplateForm = useSignal(false);
   return (
     <div class="container container-center">
       <PageTitle />
@@ -12,11 +17,30 @@ export default component$(() => {
         divider={false}
         rootClassNames="bg-white/50 dark:bg-kunai-blue-600/50"
       >
-        <div q:slot="header">
-          <h4>New Repository</h4>
+        <div q:slot="header" class="w-full">
+          <div class="flex justify-between items-center">
+            <h4>New Repository</h4>
+            <Button
+              class="cursor-pointer text-sm"
+              type="button"
+              onClick$={() =>
+                (showTemplateForm.value = !showTemplateForm.value)
+              }
+            >
+              {showTemplateForm.value
+                ? "Create from Scratch"
+                : "Create from Template"}
+            </Button>
+          </div>
         </div>
         <div q:slot="body">
-          <CreateRepositoryForm />
+          {showTemplateForm.value ? (
+            <CreateRepositoryFromTemplateForm
+              repos={repos.value.data?.repositories ?? []}
+            />
+          ) : (
+            <CreateRepositoryForm />
+          )}
         </div>
       </BaseCard>
     </div>

--- a/src/routes/layout.tsx
+++ b/src/routes/layout.tsx
@@ -5,9 +5,11 @@ import Page from "~/components/page/page";
 import Header from "~/components/header/header";
 import Footer from "~/components/footer/footer";
 import Toggle from "~/components/toggle/toggle";
-import { useCreateRepository } from "~/db/createRepository";
 import { ApplicationError } from "~/util/errors";
-export { useCreateRepository };
+export {
+  useCreateRepository,
+  useCreateTemplateRepository,
+} from "~/db/createRepository";
 export { useGetRepos } from "~/db/getRepositories";
 export { useGetPackageJson } from "~/db/getPackageJson";
 export { postWorkflowDispatchEvent } from "~/db/postWorkflowDispatchEvent";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a form to create repositories from existing templates, including validation, error handling, and success messages with direct links.
  * Users can now switch between creating a repository from scratch or from a template on the creation page.
  * Repository details pages now include tabs for parent templates and child repositories when applicable.

* **Enhancements**
  * Improved repository metadata to indicate template status and relationships.
  * Tab navigation on repository details pages is now dynamic based on repository properties.

* **Bug Fixes**
  * Validation and error display improvements in repository creation forms.

* **Chores**
  * Updated metadata to include new repositories.
  * Consolidated and updated export statements for repository creation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->